### PR TITLE
Fixing seeding missing column and validation conflicts.

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,5 +1,5 @@
 class Booking < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: true
   belongs_to :pokemon
 
   validates :status, presence: true

--- a/app/models/pokemon.rb
+++ b/app/models/pokemon.rb
@@ -4,7 +4,7 @@ class Pokemon < ApplicationRecord
   has_one_attached :picture
 
   validates :name, presence: true
-  validates :type, presence: true
+  validates :pokemon_type, presence: true
   validates :level, presence: true
   validates :location, presence: true
   validates :rate, presence: true

--- a/db/migrate/20220430170646_removed_user_id_null_value_from_bookings.rb
+++ b/db/migrate/20220430170646_removed_user_id_null_value_from_bookings.rb
@@ -1,0 +1,5 @@
+class RemovedUserIdNullValueFromBookings < ActiveRecord::Migration[6.1]
+  def change
+    change_column :bookings, :user_id, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_30_163453) do
+ActiveRecord::Schema.define(version: 2022_04_30_170646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "bookings", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.integer "user_id"
     t.bigint "pokemon_id", null: false
     t.string "status"
     t.date "start_date"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,11 +8,11 @@
 require 'faker'
 
 if User.count == 0
-puts "will create trainer..."
-user = User.create!({
-  email: "user@mewbnb.com",
-  password: "password123"
-})
+  puts "will create trainer..."
+  user = User.create!({
+    email: "user@mewbnb.com",
+    password: "password123"
+  })
 end
 
 10.times do
@@ -22,15 +22,14 @@ end
     rate: rand(50..500),
     description: Faker::Games::Pokemon.move,
     location: Faker::Games::Pokemon.location,
-    user: user,
+    user: User.first,
     pokemon_type: ["normal", "fire", "water", "grass", "electric", "ice", "fighting", "poison", "psychic", "ground", "flying", "bug", "rock", "ghost", "dark", "dragon", "steel", "fairy"].sample,
     level: rand(1..100)
   })
   puts "will create booking..."
   Booking.create!({
-    user: user,
     pokemon: pokemon,
-    status: ["available", "confirmed", "rejected"].sample,
+    status: ["available", "requested", "booked"].sample,
     start_date: Faker::Date.between(from: 10.days.ago, to: Date.today),
     end_date: Faker::Date.between(from: Date.today, to: 30.days.from_now)
   })


### PR DESCRIPTION
There was a couple of issues on the seeding PR.

1. the 'type' column named had been changed on the schema, but not in the model validation.
2. The User.id needed to be present on the booking creation which goes again the logic as the user on booking is the **Trainer** that will rent the pokemon and therefore in unknown on booking creation.

Also:
- I took the liberty to edit the booking 'status' choices, as the booking status is not about the confirmation from the Trainer standpoint, but the status of availability of the pokemon. Booking confirmation will be a simple alert handle separatly.
- I also fixed an ident style warning. :) 